### PR TITLE
Fix rendering of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,10 @@ Synchronize game saves.
 
 ## Configuration
 
-`RETRO_GAMES`: The location to which to synchronize the saves.
-`RETRO_SAVES`: The location from which to synchronize the saves.
+The following environment variables must be set to run SaveSync.
+
+`RETRO_GAMES`: The location to which to synchronize the saves. It must be an
+existing directory.
+
+`RETRO_SAVES`: The location from which to synchronize the saves. It must be an
+existing directory.


### PR DESCRIPTION
When rendering the README as HTML, the environment variables appear on
one line. A newline is being added between them to correct this.

A note is also being added that explains what this text even represents.
