### PR TITLE
Only sync files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,10 @@ struct Config {
 }
 
 fn copy_to_dest(config: &Config, path: PathBuf) {
+    if path.is_dir() {
+        debug!("skipping {}", path.display());
+        return;
+    }
     info!("copying {} to {}", path.display(), config.dest.display());
     let relative_path = make_path_relative_to_src(&config, &path);
     debug!("{}", relative_path.display());


### PR DESCRIPTION
There's no real value here in syncing empty folders. Rather than syncing
them, I'll just make them when there's a file to sync.
