### PR TITLE
Remove uses for `extern crate`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,4 @@
-extern crate env_logger;
-extern crate log;
-extern crate notify;
-
+use env_logger;
 use log::{debug, error, info};
 use notify::{DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
 use pathdiff::diff_paths;


### PR DESCRIPTION
As of [Rust 2018][changes], most uses of `extern crate` are no longer
necessary. The uses with [log] and [notify] weren't necessary because
specific items are being imported. The [env_logger] use can be replaced
with `use`.

h/t https://stackoverflow.com/a/29404692/978961

[changes]: https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html
[env_logger]: https://docs.rs/env_logger/
[log]: https://docs.rs/log/
[notify]: https://docs.rs/notify/
