### PR TITLE
Move bootstrap into the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ existing directory.
 
 `RETRO_SAVES`: The location from which to synchronize the saves. It must be an
 existing directory.
+
+The following environment variables can optionally be set when running SaveSync.
+
+`RETRO_BOOTSTRAP`: Fully synchronize the source location at startup. Possible values are `1`,
+`true`, and `yes`.


### PR DESCRIPTION
Rather than controlling the bootstrap functionality as part of the
invocation, it should be part of `Config` just like everything else. As
such, the behavior can be turned on by setting the `RETRO_BOOTSTRAP`
environment variable to a truthy value.
